### PR TITLE
Reduce Docker image size by 35x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ FROM alpine:3.10.2
 COPY --from=builder /usr/local/scripts /usr/local/scripts
 COPY --from=builder /go/bin/grpcui /usr/bin/grpcui
 RUN apk update && apk add --no-cache bash
+RUN adduser -S -u 10001 user
+USER user
 CMD ["/usr/local/scripts/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk add --no-cache git
 RUN go get -x github.com/fullstorydev/grpcui && \
     go install -x github.com/fullstorydev/grpcui/cmd/grpcui
 
-COPY scripts/start.sh /usr/local/scripts/
+COPY scripts/ /usr/local/scripts/
 RUN chmod +x /usr/local/scripts/*.sh
 
 EXPOSE 8080


### PR DESCRIPTION
Hi there,

this PR uses Docker multi-stage builds to reduce image size and use non-root user for runtime execution.  

Previous image:
```
<none>                                 <none>              823ac43af2f3        41 minutes ago      1.02GB
```

New image:
```
<none>                                 <none>              6a2be573244c        46 seconds ago       28.2MB
```

