### PR TITLE
Add support for protoset file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
-FROM golang:1.12.4-alpine AS builder
+FROM golang:1.16.0-alpine3.13 AS builder
 
 LABEL maintainer="Suparit Krityakien <suparit@wongnai.com>"
 
 RUN apk update && apk add --no-cache git
 
 RUN go get -x github.com/fullstorydev/grpcui && \
-    go install -x github.com/fullstorydev/grpcui/cmd/grpcui
+    go install -x github.com/fullstorydev/grpcui/cmd/grpcui@v1.1.0
 
 COPY scripts/ /usr/local/scripts/
 RUN chmod +x /usr/local/scripts/*.sh
 
-EXPOSE 8080
+EXPOSE 8080/tcp
 
-FROM alpine:3.10.2 
+FROM alpine:3.13.2
+
 COPY --from=builder /usr/local/scripts /usr/local/scripts
 COPY --from=builder /go/bin/grpcui /usr/bin/grpcui
+
 RUN apk update && apk add --no-cache bash
 RUN adduser -S -u 10001 user
 USER user
+
 CMD ["/usr/local/scripts/start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+image:
+	docker build -t grpcui -f Dockerfile .
+
+run-service: image
+	docker run \
+		-e GRPCUI_SERVER=172.17.0.3:6000 \
+		-p 8080:8080 \
+		--mount type=bind,source="$(PROTOSET)",target=/protoset/service.protoset \
+		grpcui

--- a/README.md
+++ b/README.md
@@ -2,15 +2,23 @@
 Docker image for https://github.com/fullstorydev/grpcui
 
 # Running a Container
+
+## With a server with reflection enabled
+
 To run a container, you need to set GRPCUI_SERVER to your grpc server (host:port).
 You should also enable reflection proto service in your grpc server so the grpc-ui can read available services/methods.
 
     docker run -eGRPCUI_SERVER=172.17.0.1:8980 -p8080:8080 wongnai/grpcui
 
+## With a server using a protoset
+
+docker run \
+	-e GRPCUI_SERVER=172.17.0.1:6000 \
+	-p 8080:8080 \
+	--mount type=bind,source="/home/wwidner/code/deproot/src/github.com/PatchSimple/dataextract/.work/artifacts/protoset/dataextract.protoset",target=/protoset/service.protoset
 
 ## Environment Variables
 | Variable      | Description                                   | Default Value |
 |---------------|-----------------------------------------------|---------------|
-| GRPCUI_PORT   | grpc-ui server port                           | 8080          |
 | GRPCUI_SERVER | grpc server host and port in host:port format |               |
 |               |                                               |               |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ You should also enable reflection proto service in your grpc server so the grpc-
     docker run \
     -e GRPCUI_SERVER=172.17.0.1:6000 \
     -p 8080:8080 \
-    --mount type=bind,source="/my/service.protoset",target=/protoset/service.protoset
+    --mount type=bind,source="/my/service.protoset",target=/protoset/service.protoset \
+    kai5263499/grpcui
 
 ## Environment Variables
 | Variable      | Description                                   | Default Value |

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You should also enable reflection proto service in your grpc server so the grpc-
 
 ## With a server using a protoset
 
-docker run \
-	-e GRPCUI_SERVER=172.17.0.1:6000 \
-	-p 8080:8080 \
-	--mount type=bind,source="/home/wwidner/code/deproot/src/github.com/PatchSimple/dataextract/.work/artifacts/protoset/dataextract.protoset",target=/protoset/service.protoset
+    docker run \
+    -e GRPCUI_SERVER=172.17.0.1:6000 \
+    -p 8080:8080 \
+    --mount type=bind,source="/my/service.protoset",target=/protoset/service.protoset
 
 ## Environment Variables
 | Variable      | Description                                   | Default Value |

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-grpcui -bind 0.0.0.0 -plaintext -port ${GRPCUI_PORT:-8080} ${GRPCUI_SERVER:-}
+: ${PROTOSET:=""}
+if [[ -f /protoset/service.protoset ]]; then
+    PROTOSET="-protoset /protoset/service.protoset"
+fi
+
+grpcui -bind 0.0.0.0 ${PROTOSET} -plaintext -port 8080 ${GRPCUI_SERVER:-}


### PR DESCRIPTION
I have a service that cannot use the gRPC reflection protocol. But I discovered that gRPC UI can accept protosets and work just fine. This change adds the ability to mount a protoset from the host into the container and use it for RPC discovery 